### PR TITLE
fix: prevent partial-edit loops on agent state files

### DIFF
--- a/.agent/MACHINE.md
+++ b/.agent/MACHINE.md
@@ -28,6 +28,17 @@ On every ACTION:
 5. If this was the last step: fill Outcome in PLAN.md.
 6. Record any new technical debt in MEMORY.md
 
+## File update strategy
+
+When updating any `.agent/*.md` file:
+1. Read the current content
+2. Compose the full new content in memory  
+3. Write the entire file
+
+Do not apply partial edits to agent state files. These files contain
+repeated structural patterns that break partial-edit tools regardless
+of implementation.
+
 ## Code standards
 
 - Every function does one thing completely

--- a/.agent/MEMORY.md
+++ b/.agent/MEMORY.md
@@ -3,9 +3,11 @@
 > Shared state for JINX and MACHINE.
 > Read completely before any action. Update after every meaningful change.
 > Delete stale content — do not annotate history.
+> **Update rule: always Read → modify in memory → Write full file.**
 
 ---
 
+<!-- SECTION:project -->
 ## Project
 
 **Name:**
@@ -15,9 +17,11 @@
 **Architecture:**
 **Entry points:**
 **State:** [ early dev | stable | refactor | legacy ]
+<!-- /SECTION:project -->
 
 ---
 
+<!-- SECTION:conventions -->
 ## Conventions
 
 **Naming:**
@@ -42,18 +46,22 @@
 ```
 /
 ```
+<!-- /SECTION:conventions -->
 
 ---
 
+<!-- SECTION:environment -->
 ## Environment
 
 **Local setup:**
 **Required env vars:**
 **External services:**
 **Ports / endpoints:**
+<!-- /SECTION:environment -->
 
 ---
 
+<!-- SECTION:active-decisions -->
 ## Active Decisions
 
 > Architectural and structural decisions already made. Do not re-open without reason.
@@ -61,9 +69,11 @@
 | Decision | Reason | Alternatives rejected | Made by |
 |----------|--------|-----------------------|---------|
 | | | | |
+<!-- /SECTION:active-decisions -->
 
 ---
 
+<!-- SECTION:conflict-resolution -->
 ## Conflict Resolution Protocol
 
 > How contradictions between state files are resolved during boot.
@@ -75,17 +85,21 @@ When the same fact appears in multiple files with different values:
 3. The losing value is discarded — not archived.
 
 Rationale: ACTION files are the most recent intent; MEMORY.md is the most stable baseline. More specific/recent always overrides more general/older.
+<!-- /SECTION:conflict-resolution -->
 
 ---
 
+<!-- SECTION:known-constraints -->
 ## Known Constraints
 
 > Hard limits that shape every implementation decision. Non-negotiable unless explicitly changed.
 
 -
+<!-- /SECTION:known-constraints -->
 
 ---
 
+<!-- SECTION:technical-debt -->
 ## Technical Debt
 
 > Record when created. Remove when resolved.
@@ -93,17 +107,21 @@ Rationale: ACTION files are the most recent intent; MEMORY.md is the most stable
 | Debt | Created at | Impact | Owner |
 |------|-----------|--------|-------|
 | | | | |
+<!-- /SECTION:technical-debt -->
 
 ---
 
+<!-- SECTION:user-preferences -->
 ## User Preferences
 
 > Durable behavior changes. Updated only when user requests explicitly.
 
 -
+<!-- /SECTION:user-preferences -->
 
 ---
 
+<!-- SECTION:directory-index -->
 ## Directory Index
 
 > Subdirectories with distinct responsibility. Update when structure changes.
@@ -111,6 +129,7 @@ Rationale: ACTION files are the most recent intent; MEMORY.md is the most stable
 | Path | Purpose | MEMORY.md |
 |------|---------|-----------|
 | | | [ yes \| no ] |
+<!-- /SECTION:directory-index -->
 
 ---
 

--- a/.agent/PLAN.md
+++ b/.agent/PLAN.md
@@ -1,36 +1,50 @@
 # PLAN
 
+> **Update rule: always Read → modify in memory → Write full file.**
+
+<!-- SECTION:goal -->
 ## Goal
 
+<!-- /SECTION:goal -->
 
+<!-- SECTION:context -->
 ## Context
 > Why this task exists. What breaks or becomes possible after it's done.
 
+<!-- /SECTION:context -->
 
+<!-- SECTION:approach -->
 ## Approach
 > The chosen direction and the reason. Alternatives considered go here too.
 
+<!-- /SECTION:approach -->
 
+<!-- SECTION:steps -->
 ## Steps
 
 - [ ] → ACTION_*
+<!-- /SECTION:steps -->
 
-
+<!-- SECTION:blockers -->
 ## Blockers
 > Anything that stopped or slowed execution. Resolved blockers stay here — they explain why steps took the shape they did.
 
+<!-- /SECTION:blockers -->
 
+<!-- SECTION:decisions -->
 ## Decisions made during execution
 > Choices MACHINE made that weren't in the original plan. Each one needs a reason.
 
 | Decision | Reason | Step |
 |----------|--------|------|
 | | | |
+<!-- /SECTION:decisions -->
 
-
+<!-- SECTION:outcome -->
 ## Outcome
 > Filled when all steps are done. What was actually built vs what was planned. Any delta explained.
 
+<!-- /SECTION:outcome -->
 
 ---
 *Created by: JINX*


### PR DESCRIPTION
## Problem

Claude Code CLI (and similar agentic CLI tools) use partial-edit tools (e.g. str_replace_editor) that require an exact unique match of the target string in the file. MEMORY.md and PLAN.md contain repeated structural patterns — empty table rows, `---` separators, `- [ ]` items — that are not unique. This caused MACHINE to fall into a Read → failed edit → Read loop on every state file update, increasing token usage and slowing execution.

## Changes

**MACHINE.md**
- Added `## File update strategy` section with an explicit rule: always Read → compose full content in memory → Write entire file. No partial edits on agent state files, regardless of editor/tool used.
- Rule is placed here only. JINX creates state files from scratch (always a full Write by nature), so the rule does not apply to it.

**MEMORY.md / PLAN.md**
- Added HTML comment anchors (`<!-- SECTION:name -->`) around every section as a secondary safeguard. If a partial-edit tool is ever used, each block is now structurally unique and can be targeted safely.

## What was not changed

- Agent logic, boot sequence, and contracts are unchanged.
- JINX.md is unchanged — JINX only creates files, never incrementally updates them.
- Rule is intentionally absent from MEMORY.md: it is behavioral guidance for MACHINE, not a project convention.