### PR TITLE
Remove forced flow-style YAML serialization

### DIFF
--- a/.agent/src/jinx/prompts.py
+++ b/.agent/src/jinx/prompts.py
@@ -102,7 +102,11 @@ MISSING_STATE_WARNING: str = (
 TOOL_DEPTH_CRITICAL_MSG: str = (
     "CRITICAL: The inner tool-calling depth limit has been reached. "
     "Do not call any more tools. You must immediately output your final thought "
-    "and the exact, complete markdown YAML code block (```yaml ... ```) to persist your progress and avoid state loss."
+    "and the exact, complete markdown YAML code block (```yaml ... ```) to persist your progress and avoid state loss.\n"
+    "Being cut off here does NOT mean the task is done — only set 'exit_ready: true' if the requirements "
+    "genuinely all passed. Otherwise set it false and describe what's left in 'open', so the next round can "
+    "continue from an honest state. Re-send the FULL 'scores' history (every prior round plus this one), "
+    "not just a summary of this round — this is the same rule as every other round."
 )
 
 
@@ -122,7 +126,7 @@ def construct_round_prompt(
         str: The fully-formed, formatted user prompt string for the cognitive loop.
     """
     warning_prefix = MISSING_STATE_WARNING if missing_state else ""
-    return f"{warning_prefix}ROUND {rnd} of {min_rounds}+\nTASK: {task}\nCURRENT STATE:\n{state_dump}"
+    return f"{warning_prefix}ROUND {rnd} (at least {min_rounds} rounds required before exit is considered)\nTASK: {task}\nCURRENT STATE:\n{state_dump}"
 
 
 

--- a/.agent/src/jinx/prompts.py
+++ b/.agent/src/jinx/prompts.py
@@ -94,7 +94,9 @@ deadlock: <true|false — true only if 3+ genuinely different approaches failed 
 MISSING_STATE_WARNING: str = (
     "WARNING: You did not output the REQUIRED markdown YAML state block (```yaml ... ```) at the end of your last response!\n"
     "You MUST output the updated state block with your final evaluation (including 'exit_ready: true' if the task is finished) "
-    "so that JINX can parse it, update the state, and terminate cleanly. Do not skip this block!\n\n"
+    "so that JINX can parse it, update the state, and terminate cleanly. Do not skip this block!\n"
+    "Use CURRENT STATE below as your starting point — re-send the FULL 'scores' history (every prior round "
+    "plus this one), not just the latest entry, or earlier rounds will be permanently lost.\n\n"
 )
 
 TOOL_DEPTH_CRITICAL_MSG: str = (

--- a/.agent/src/jinx/prompts.py
+++ b/.agent/src/jinx/prompts.py
@@ -25,44 +25,64 @@ TEST: You have access to bash_exec, file_read, and file_write tools.
   CRITICAL: Never describe changes in conversational text; doing so does NOT modify disk. You MUST explicitly call `file_write` to create/edit files and `bash_exec` to run commands. Text descriptions are non-operational.
 SCORE: Per-requirement pass/fail. Not holistic.
 GATE BEFORE COMMIT: Functional end-to-end verification required.
+You cannot finish on round 1 even if everything passes — at least 2 rounds of evidence are always required before exit is possible, regardless of the configured minimum.
 
-STATE PERSISTENCE: Between rounds, your state lives in JINX.yaml on disk. You MUST return an updated state block at the end of your response.
+STATE PERSISTENCE — READ CAREFULLY, THIS IS WHERE MOST FAILURES HAPPEN:
+Your state lives in JINX.yaml on disk. You MUST return an updated state block at the end of every response.
 
-APPROACH KNOWLEDGE GRAPH:
-To enable smart deadlock detection, you must model your technical approach for each strategy round as an explicit semantic knowledge graph under `approach_graph`.
-- `nodes`: Structured list of key entities (e.g. files, tools, actions, or concepts), each containing a unique `id` and a `type` (e.g., 'file', 'tool', 'action', 'concept').
-- `edges`: Semantic directed links between those nodes, containing `source` node ID, `target` node ID, and a descriptive relationship label `relation` (e.g., 'reads', 'modifies', 'tests', 'depends_on').
+- `scores` is your COMPLETE history, not just this round. Each round you must re-send EVERY prior round's
+  entry PLUS the new one appended. Sending only the current round's entry PERMANENTLY DELETES all earlier
+  rounds from disk — deadlock detection and exit criteria depend entirely on that full history.
+- `facts`, `debt`, and `open` follow the same rule: each is replaced wholesale by whatever you send. If you
+  have nothing new to add, repeat the full existing list from CURRENT STATE rather than omitting it or
+  sending a partial one.
+- `requirements` keys (e.g. `req_name` below) must be the exact same strings every round for the same
+  requirement. Renaming a requirement between rounds breaks deadlock clustering, which matches failures by
+  literal key name.
+- `exit_ready` and `deadlock` must always be included explicitly as real booleans (`true`/`false`, not
+  strings) — never omit them.
+- Your ENTIRE state block is validated as one unit. One malformed field anywhere inside it — including deep
+  inside `approach_graph` — causes the WHOLE block to be rejected and discarded, not just that field. When
+  in doubt, leave `approach_graph` out entirely rather than send an incomplete one.
+- Output EXACTLY ONE ```yaml fenced code block, and it must be the LAST fenced block in your response. If
+  you show any other ```yaml/```json/```yml block earlier (e.g. while reading a config file during TEST),
+  that is fine, but never let one appear after your actual state block.
 
-REQUIRED — end every response with a standard markdown YAML code block containing the updated state:
+APPROACH KNOWLEDGE GRAPH (optional — include only when it helps):
+When a requirement has failed more than once, you may model your technical approach as a semantic knowledge
+graph under `approach_graph` so deadlock detection can tell genuinely different strategies apart from
+superficial rewordings. If you include it, every node needs both `id` and `type`, and every edge needs
+`source`, `target`, and `relation` — incomplete graphs reject the entire state block (see above), so omit
+it on rounds where you can't fill it out correctly.
+- `nodes`: key entities (files, tools, actions, or concepts), each with a unique `id` and a `type` (one of
+  'file', 'tool', 'action', 'concept').
+- `edges`: directed links between those nodes — `source` node ID, `target` node ID, and a `relation` label
+  (e.g. 'reads', 'modifies', 'tests', 'depends_on').
+
+REQUIRED — end every response with exactly one markdown YAML code block containing the updated state. The
+schema below shows the SHAPE of each field, not data to copy — replace every value with this task's real
+current state, and remember `scores`/`facts`/`debt`/`open` must each be the full list, not just new items:
 ```yaml
-task: "task as understood"
-facts:
-  - "scope facts"
-  - "constraints found"
+task: <string — restate the task as you understand it>
+facts: [<every known scope fact/constraint so far, not just new ones>]
 scores:
   - round: 1
-    approach: "approach name"
-    prior_failure: "what failed before this round"
-    requirements:
-      req_name: true
-    pass_count: 1
-    all_pass: false
-    approach_graph:
-      nodes:
-        - id: "auth_service"
-          type: "file"
-        - id: "unit_tests"
-          type: "action"
-      edges:
-        - source: "unit_tests"
-          target: "auth_service"
-          relation: "tests"
-debt:
-  - "shortcuts taken"
-open:
-  - "unresolved issues"
-exit_ready: false
-deadlock: false
+    approach: <short name for round 1's strategy>
+    prior_failure: <what failed before round 1; "none" if this is round 1>
+    requirements: {<requirement_name>: <true|false>}
+    pass_count: <int — how many requirements passed>
+    all_pass: <true|false>
+  - round: 2
+    approach: <short name for round 2's strategy — must differ from round 1's>
+    prior_failure: <exactly what round 1 failed on>
+    requirements: {<requirement_name>: <true|false>}
+    pass_count: <int>
+    all_pass: <true|false>
+  # ... one entry per round so far, oldest first, nothing dropped
+debt: [<every shortcut taken so far, not just new ones>]
+open: [<every unresolved issue so far, not just new ones>]
+exit_ready: <true|false — true only once all_pass is true on the latest round AND you are not still improving>
+deadlock: <true|false — true only if 3+ genuinely different approaches failed the same requirement>
 ```
 """
 

--- a/.agent/src/jinx/prompts.py
+++ b/.agent/src/jinx/prompts.py
@@ -127,6 +127,3 @@ def construct_round_prompt(
     """
     warning_prefix = MISSING_STATE_WARNING if missing_state else ""
     return f"{warning_prefix}ROUND {rnd} (at least {min_rounds} rounds required before exit is considered)\nTASK: {task}\nCURRENT STATE:\n{state_dump}"
-
-
-

--- a/.agent/src/jinx/runner.py
+++ b/.agent/src/jinx/runner.py
@@ -36,15 +36,6 @@ HARD_CAP: int = 40
 TOOL_DEPTH_CAP: int = 20
 
 
-# Custom types to enforce flow style (compact inline format) for specific sub-elements in YAML
-class FlowDict(dict):
-    pass
-
-
-class FlowList(list):
-    pass
-
-
 class Dumper(yaml.SafeDumper):
     """Isolated, thread-safe PyYAML dumper class for JINX serialization.
 
@@ -59,14 +50,6 @@ JinxYamlDumper = Dumper
 JinxEnterpriseYamlDumper = Dumper
 
 
-def flow_dict_representer(dumper: Dumper, data: FlowDict) -> Any:
-    return dumper.represent_mapping('tag:yaml.org,2002:map', data, flow_style=True)
-
-
-def flow_list_representer(dumper: Dumper, data: FlowList) -> Any:
-    return dumper.represent_sequence('tag:yaml.org,2002:seq', data, flow_style=True)
-
-
 def str_presenter(dumper: Dumper, data: str) -> Any:
     if '\n' in data:
         # Format multi-line strings cleanly using literal block scalars (|)
@@ -75,23 +58,7 @@ def str_presenter(dumper: Dumper, data: str) -> Any:
 
 
 # Register representers strictly and exclusively to our custom dumper class
-Dumper.add_representer(FlowDict, flow_dict_representer)
-Dumper.add_representer(FlowList, flow_list_representer)
 Dumper.add_representer(str, str_presenter)
-
-
-def to_flow(data: Any) -> Any:
-    """Recursively converts standard dictionaries and lists into FlowDict/FlowList mappings.
-
-    This forces the YAML dumper to represent complex nested data compact in flow style,
-    while leaving top-level textual descriptions in beautiful human-readable block style.
-    """
-    if isinstance(data, dict):
-        return FlowDict({k: to_flow(v) for k, v in data.items()})
-    elif isinstance(data, list):
-        return FlowList([to_flow(v) for v in data])
-    return data
-
 
 
 # Custom Enterprise Exception Hierarchy
@@ -119,12 +86,17 @@ class Yaml:
     """Thread-safe YAML serialization engine for JINX operations.
 
     Consolidates isolated PyYAML configurations, atomic transactional file writes,
-    and safe parsing logic.
+    and safe parsing logic. All output uses block style exclusively (no inline/flow
+    style) for maximum readability and to minimize LLM state-block parsing errors.
     """
 
     @staticmethod
     def dump_to_string(data: Any, width: int = sys.maxsize) -> str:
-        """Serializes structures to YAML strings using our custom isolated dumper."""
+        """Serializes structures to YAML strings using our custom isolated dumper.
+
+        Always renders in block style (default_flow_style=False); nested dicts/lists
+        are never collapsed into compact inline `{...}`/`[...]` form.
+        """
         try:
             return yaml.dump(
                 data,
@@ -139,7 +111,11 @@ class Yaml:
 
     @staticmethod
     def safe_atomic_write(path: Path, data: Any, width: int = sys.maxsize) -> None:
-        """Writes data structures to files atomically via temporary staging files."""
+        """Writes data structures to files atomically via temporary staging files.
+
+        Always renders in block style (default_flow_style=False) for consistency
+        with dump_to_string.
+        """
         temp_path = path.with_suffix(path.suffix + ".tmp")
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -531,7 +507,7 @@ def write_llm_request(
         "type": "llm_generate",
         "system": SYSTEM_PROMPT,
         "messages": history,
-        "tools": to_flow(tool_schema())
+        "tools": tool_schema()
     }
     try:
         Yaml.safe_atomic_write(REQUEST_PATH, request_payload)
@@ -668,7 +644,7 @@ def run_file_ipc(task: Optional[str], min_override: Optional[int]) -> None:
                 # Post tool executions back to editor
                 request_payload = {
                     "type": "tool_calls",
-                    "calls": to_flow(tool_calls)
+                    "calls": tool_calls
                 }
                 try:
                     Yaml.safe_atomic_write(REQUEST_PATH, request_payload)
@@ -754,7 +730,7 @@ def run_file_ipc(task: Optional[str], min_override: Optional[int]) -> None:
                     "type": "llm_generate",
                     "system": SYSTEM_PROMPT,
                     "messages": history,
-                    "tools": to_flow([])
+                    "tools": []
                 }
                 try:
                     Yaml.safe_atomic_write(REQUEST_PATH, request_payload)
@@ -943,4 +919,3 @@ def run(task: Optional[str], min_override: Optional[int], ipc_mode: str = "file"
     else:
         logger.error("Cognitive loop exhausted HARD_CAP (%d rounds) without resolution.", HARD_CAP)
         sys.exit(2)
-

--- a/.agent/src/jinx/runner.py
+++ b/.agent/src/jinx/runner.py
@@ -36,6 +36,16 @@ HARD_CAP: int = 40
 TOOL_DEPTH_CAP: int = 20
 
 
+class FlowDict(dict):
+    """Deprecated: flow-style forcing removed. Kept as no-op alias for backward compatibility."""
+    pass
+
+
+class FlowList(list):
+    """Deprecated: flow-style forcing removed. Kept as no-op alias for backward compatibility."""
+    pass
+
+
 class Dumper(yaml.SafeDumper):
     """Isolated, thread-safe PyYAML dumper class for JINX serialization.
 
@@ -50,6 +60,16 @@ JinxYamlDumper = Dumper
 JinxEnterpriseYamlDumper = Dumper
 
 
+def flow_dict_representer(dumper: Dumper, data: "FlowDict") -> Any:
+    """Deprecated no-op: no longer forces flow style; mappings render in block style."""
+    return dumper.represent_mapping('tag:yaml.org,2002:map', data, flow_style=False)
+
+
+def flow_list_representer(dumper: Dumper, data: "FlowList") -> Any:
+    """Deprecated no-op: no longer forces flow style; sequences render in block style."""
+    return dumper.represent_sequence('tag:yaml.org,2002:seq', data, flow_style=False)
+
+
 def str_presenter(dumper: Dumper, data: str) -> Any:
     if '\n' in data:
         # Format multi-line strings cleanly using literal block scalars (|)
@@ -58,7 +78,16 @@ def str_presenter(dumper: Dumper, data: str) -> Any:
 
 
 # Register representers strictly and exclusively to our custom dumper class
+Dumper.add_representer(FlowDict, flow_dict_representer)
+Dumper.add_representer(FlowList, flow_list_representer)
 Dumper.add_representer(str, str_presenter)
+
+
+def to_flow(data: Any) -> Any:
+    """Deprecated: previously forced compact flow-style YAML. Now a no-op that
+    returns standard dict/list structures unchanged; all output renders in block style.
+    """
+    return data
 
 
 # Custom Enterprise Exception Hierarchy
@@ -86,8 +115,9 @@ class Yaml:
     """Thread-safe YAML serialization engine for JINX operations.
 
     Consolidates isolated PyYAML configurations, atomic transactional file writes,
-    and safe parsing logic. All output uses block style exclusively (no inline/flow
-    style) for maximum readability and to minimize LLM state-block parsing errors.
+    and safe parsing logic. Block style is preferred for non-empty mappings/sequences
+    for maximum readability and to minimize LLM state-block parsing errors (PyYAML
+    may still render empty collections like `[]`/`{}` compactly).
     """
 
     @staticmethod

--- a/.agent/src/jinx/runner.py
+++ b/.agent/src/jinx/runner.py
@@ -36,16 +36,6 @@ HARD_CAP: int = 40
 TOOL_DEPTH_CAP: int = 20
 
 
-class FlowDict(dict):
-    """Deprecated: flow-style forcing removed. Kept as no-op alias for backward compatibility."""
-    pass
-
-
-class FlowList(list):
-    """Deprecated: flow-style forcing removed. Kept as no-op alias for backward compatibility."""
-    pass
-
-
 class Dumper(yaml.SafeDumper):
     """Isolated, thread-safe PyYAML dumper class for JINX serialization.
 
@@ -60,16 +50,6 @@ JinxYamlDumper = Dumper
 JinxEnterpriseYamlDumper = Dumper
 
 
-def flow_dict_representer(dumper: Dumper, data: "FlowDict") -> Any:
-    """Deprecated no-op: no longer forces flow style; mappings render in block style."""
-    return dumper.represent_mapping('tag:yaml.org,2002:map', data, flow_style=False)
-
-
-def flow_list_representer(dumper: Dumper, data: "FlowList") -> Any:
-    """Deprecated no-op: no longer forces flow style; sequences render in block style."""
-    return dumper.represent_sequence('tag:yaml.org,2002:seq', data, flow_style=False)
-
-
 def str_presenter(dumper: Dumper, data: str) -> Any:
     if '\n' in data:
         # Format multi-line strings cleanly using literal block scalars (|)
@@ -78,16 +58,7 @@ def str_presenter(dumper: Dumper, data: str) -> Any:
 
 
 # Register representers strictly and exclusively to our custom dumper class
-Dumper.add_representer(FlowDict, flow_dict_representer)
-Dumper.add_representer(FlowList, flow_list_representer)
 Dumper.add_representer(str, str_presenter)
-
-
-def to_flow(data: Any) -> Any:
-    """Deprecated: previously forced compact flow-style YAML. Now a no-op that
-    returns standard dict/list structures unchanged; all output renders in block style.
-    """
-    return data
 
 
 # Custom Enterprise Exception Hierarchy
@@ -115,9 +86,8 @@ class Yaml:
     """Thread-safe YAML serialization engine for JINX operations.
 
     Consolidates isolated PyYAML configurations, atomic transactional file writes,
-    and safe parsing logic. Block style is preferred for non-empty mappings/sequences
-    for maximum readability and to minimize LLM state-block parsing errors (PyYAML
-    may still render empty collections like `[]`/`{}` compactly).
+    and safe parsing logic. All output uses block style exclusively (no inline/flow
+    style) for maximum readability and to minimize LLM state-block parsing errors.
     """
 
     @staticmethod

--- a/tests/enterprise_plugins/verify_runner.py
+++ b/tests/enterprise_plugins/verify_runner.py
@@ -33,22 +33,6 @@ class VerifyRunnerPhase(VerificationPhase):
             return False
 
         # --- CLASS VERIFICATIONS ---
-        # Verify Class FlowDict
-        if hasattr(target_module, "FlowDict"):
-            suite.print_badge("Class FlowDict: PRESENT", True)
-            cls_obj = getattr(target_module, "FlowDict")
-        else:
-            suite.print_badge("Class FlowDict: MISSING", False)
-            success = False
-
-        # Verify Class FlowList
-        if hasattr(target_module, "FlowList"):
-            suite.print_badge("Class FlowList: PRESENT", True)
-            cls_obj = getattr(target_module, "FlowList")
-        else:
-            suite.print_badge("Class FlowList: MISSING", False)
-            success = False
-
         # Verify Class Dumper
         if hasattr(target_module, "Dumper"):
             suite.print_badge("Class Dumper: PRESENT", True)
@@ -113,32 +97,11 @@ class VerifyRunnerPhase(VerificationPhase):
             success = False
 
         # --- FUNCTION VERIFICATIONS ---
-        # Verify Function flow_dict_representer
-        if hasattr(target_module, "flow_dict_representer"):
-            suite.print_badge("Function flow_dict_representer: PRESENT", True)
-        else:
-            suite.print_badge("Function flow_dict_representer: MISSING", False)
-            success = False
-
-        # Verify Function flow_list_representer
-        if hasattr(target_module, "flow_list_representer"):
-            suite.print_badge("Function flow_list_representer: PRESENT", True)
-        else:
-            suite.print_badge("Function flow_list_representer: MISSING", False)
-            success = False
-
         # Verify Function str_presenter
         if hasattr(target_module, "str_presenter"):
             suite.print_badge("Function str_presenter: PRESENT", True)
         else:
             suite.print_badge("Function str_presenter: MISSING", False)
-            success = False
-
-        # Verify Function to_flow
-        if hasattr(target_module, "to_flow"):
-            suite.print_badge("Function to_flow: PRESENT", True)
-        else:
-            suite.print_badge("Function to_flow: MISSING", False)
             success = False
 
         # Verify Function safe_atomic_write_yaml


### PR DESCRIPTION
Deleted FlowDict, FlowList, to_flow(), flow_dict_representer, flow_list_representer All YAML output now consistently uses block style (default_flow_style=False is no longer overridden for tools/tool_calls) Updated the 3 call sites (tool_schema(), tool_calls, []) to pass data directly, no wrapping No change to data semantics, JSON IPC, or business logic — verified via round-trip tests and full file-IPC loop simulation (task → tool_use → tool_calls → tool_result → next round)

Goal: more readable YAML for the LLM, fewer state-block parsing errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Улучшена стабильность YAML-вывода: вложенные структуры больше не сворачиваются в inline-формат и всегда отрисовываются в фиксированном block-стиле.
  * Исправлена отправка данных при работе с инструментами: схемы и вызовы передаются напрямую, включая сценарии принудительного завершения по лимиту.
* **Documentation**
  * Обновлены системные подсказки: усилены правила LOOP PROTOCOL, требования к целостности state и к формату ответа (ровно один финальный fenced YAML-блок), а также к пересылке полной истории `scores`.
* **Tests**
  * Обновлены проверки enterprise-плагинов: убраны ожидания устаревших средств flow-формата YAML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->